### PR TITLE
[WIP] refactor to make publish work with create_stream API

### DIFF
--- a/examples/connect.rs
+++ b/examples/connect.rs
@@ -5,27 +5,26 @@ use std::time::Duration;
 use url::Url;
 
 fn main() {
-  pretty_env_logger::init();
+    pretty_env_logger::init();
 
-  let addr = "127.0.0.1:1935";
+    let addr = "127.0.0.1:1935";
 
-  let url = Url::parse(&format!("rtmp://{}/vod/media", addr)).expect("url parse");
+    let url = Url::parse(&format!("rtmp://{}/vod/media", addr)).expect("url parse");
 
-  let mut conn = rtmp::Connection::new(url);
-  // optional set timeout to 1 sec: conn.set_timeout(1000);
-  conn
-    .connect_with_callback(|response| {
-      println!("connect response: {:?}", response);
-      exit(0);
+    let mut conn = rtmp::Connection::new(url, None);
+    // optional set timeout to 1 sec: conn.set_timeout(1000);
+    conn.connect_with_callback(|response| {
+        println!("connect response: {:?}", response);
+        exit(0);
     })
     .expect("rtmp connect");
-  println!("waiting");
+    println!("waiting");
 
-  let some_time = Duration::from_millis(100);
-  loop {
-    sleep(some_time);
-  }
-  // let mut input = String::new();
-  // println!("press return to quit");
-  // std::io::stdin().read_line(&mut input).expect("stdio read_line");
+    let some_time = Duration::from_millis(100);
+    loop {
+        sleep(some_time);
+    }
+    // let mut input = String::new();
+    // println!("press return to quit");
+    // std::io::stdin().read_line(&mut input).expect("stdio read_line");
 }

--- a/examples/publish.rs
+++ b/examples/publish.rs
@@ -4,35 +4,35 @@ use std::time::Duration;
 use url::Url;
 
 fn stream_callback(msg: rtmp::Message) {
-    println!("===================> stream_callback: {:?}", msg);
+  println!("===================> stream_callback: {:?}", msg);
 }
 
 fn main() {
-    pretty_env_logger::init();
+  pretty_env_logger::init();
 
-    let addr = "127.0.0.1:1935";
+  let addr = "127.0.0.1:1935";
 
-    let url = Url::parse(&format!("rtmp://{}/live/mystream", addr)).expect("url parse");
+  let url = Url::parse(&format!("rtmp://{}/live/mystream", addr)).expect("url parse");
 
-    let mut conn = rtmp::Connection::new(url, Some(stream_callback));
-    //let stream =
-    conn.new_stream();
+  let mut conn = rtmp::Connection::new(url, Some(stream_callback));
+  //let stream = conn.new_stream();
 
-    // optional set timeout to 1 sec: conn.set_timeout(1000);
-    conn.connect_with_callback(move |response| {
-        println!("===> connect response: {:?}", response);
-        // TODO hack: publish called automatically on successful create
-        // stream.publish("mystream".to_string(), rtmp::RecordFlag::Live);
-        // println!("===> published: {}", stream);
+  // optional set timeout to 1 sec: conn.set_timeout(1000);
+  conn
+    .connect_with_callback(move |response| {
+      println!("===> connect response: {:?}", response);
+      // TODO hack: publish called automatically on successful create
+      // stream.publish("mystream".to_string(), rtmp::RecordFlag::Live);
+      // println!("===> published: {}", stream);
     })
     .expect("rtmp connect");
-    println!("waiting");
+  println!("waiting");
 
-    let some_time = Duration::from_millis(100);
-    loop {
-        sleep(some_time);
-    }
-    // let mut input = String::new();
-    // println!("press return to quit");
-    // std::io::stdin().read_line(&mut input).expect("stdio read_line");
+  let some_time = Duration::from_millis(100);
+  loop {
+    sleep(some_time);
+  }
+  // let mut input = String::new();
+  // println!("press return to quit");
+  // std::io::stdin().read_line(&mut input).expect("stdio read_line");
 }

--- a/examples/publish.rs
+++ b/examples/publish.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use url::Url;
 
 fn stream_callback(msg: rtmp::Message) {
-    print!("stream_callback: {:?}", msg);
+    println!("===================> stream_callback: {:?}", msg);
 }
 
 fn main() {

--- a/examples/publish.rs
+++ b/examples/publish.rs
@@ -3,7 +3,7 @@ use std::thread::sleep;
 use std::time::Duration;
 use url::Url;
 
-fn stream_callback(msg: rtmp::Message) {
+fn stream_callback(conn: rtmp::Connection, msg: rtmp::Message) {
   println!("===================> stream_callback: {:?}", msg);
 }
 

--- a/examples/publish.rs
+++ b/examples/publish.rs
@@ -3,33 +3,36 @@ use std::thread::sleep;
 use std::time::Duration;
 use url::Url;
 
+fn stream_callback(msg: rtmp::Message) {
+    print!("stream_callback: {:?}", msg);
+}
+
 fn main() {
-  pretty_env_logger::init();
+    pretty_env_logger::init();
 
-  let addr = "127.0.0.1:1935";
+    let addr = "127.0.0.1:1935";
 
-  let url = Url::parse(&format!("rtmp://{}/live/mystream", addr)).expect("url parse");
+    let url = Url::parse(&format!("rtmp://{}/live/mystream", addr)).expect("url parse");
 
-  let mut conn = rtmp::Connection::new(url);
-  //let stream =
-  conn.new_stream();
+    let mut conn = rtmp::Connection::new(url, Some(stream_callback));
+    //let stream =
+    conn.new_stream();
 
-  // optional set timeout to 1 sec: conn.set_timeout(1000);
-  conn
-    .connect_with_callback(move |response| {
-      println!("===> connect response: {:?}", response);
-      // TODO hack: publish called automatically on successful create
-      // stream.publish("mystream".to_string(), rtmp::RecordFlag::Live);
-      // println!("===> published: {}", stream);
+    // optional set timeout to 1 sec: conn.set_timeout(1000);
+    conn.connect_with_callback(move |response| {
+        println!("===> connect response: {:?}", response);
+        // TODO hack: publish called automatically on successful create
+        // stream.publish("mystream".to_string(), rtmp::RecordFlag::Live);
+        // println!("===> published: {}", stream);
     })
     .expect("rtmp connect");
-  println!("waiting");
+    println!("waiting");
 
-  let some_time = Duration::from_millis(100);
-  loop {
-    sleep(some_time);
-  }
-  // let mut input = String::new();
-  // println!("press return to quit");
-  // std::io::stdin().read_line(&mut input).expect("stdio read_line");
+    let some_time = Duration::from_millis(100);
+    loop {
+        sleep(some_time);
+    }
+    // let mut input = String::new();
+    // println!("press return to quit");
+    // std::io::stdin().read_line(&mut input).expect("stdio read_line");
 }

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -1,12 +1,14 @@
 use log::{info, trace, warn};
+use std::sync::{Arc, Mutex};
+
 use std::sync::atomic::{AtomicUsize, Ordering};
+use tokio::runtime::Runtime;
 use tokio::sync::mpsc;
 use url::Url;
 
 use crate::amf::Value;
 use crate::stream::*;
 use crate::Message;
-use tokio::runtime::Runtime;
 
 mod inner;
 use inner::InnerConnection;
@@ -20,98 +22,105 @@ pub mod handshake;
 const CHANNEL_SIZE: usize = 100;
 
 pub struct Connection {
-    url: Url,
-    runtime: Runtime,
-    next_cmd_id: AtomicUsize,
-    to_server_tx: mpsc::Sender<Message>, // messages destined for server go here
-    to_server_rx: Option<mpsc::Receiver<Message>>, // process loop grabs them from here
+  url: Url,
+  runtime_guard: Arc<Mutex<Runtime>>,
+  next_cmd_id: AtomicUsize,
+  to_server_tx: mpsc::Sender<Message>, // messages destined for server go here
+  to_server_rx: Option<mpsc::Receiver<Message>>, // process loop grabs them from here
 }
 
 impl Connection {
-    // todo: new_with_transport, then new can defer creation of connection
-    pub fn new(url: Url) -> Self {
-        info!(target: "rtmp::Connection", "new");
-        let runtime = tokio::runtime::Runtime::new().unwrap();
-        let (to_server_tx, to_server_rx) = mpsc::channel::<Message>(CHANNEL_SIZE);
+  // todo: new_with_transport, then new can defer creation of connection
+  pub fn new(url: Url) -> Self {
+    info!(target: "rtmp::Connection", "new");
+    let runtime = tokio::runtime::Runtime::new().expect("new Runtime");
+    let (to_server_tx, to_server_rx) = mpsc::channel::<Message>(CHANNEL_SIZE);
 
-        Connection {
-            url,
-            runtime,
-            next_cmd_id: AtomicUsize::new(2),
-            to_server_tx,
-            to_server_rx: Some(to_server_rx), // consumed by process_loop
-        }
+    Connection {
+      url,
+      runtime_guard: Arc::new(Mutex::new(runtime)),
+      next_cmd_id: AtomicUsize::new(2),
+      to_server_tx,
+      to_server_rx: Some(to_server_rx), // consumed by process_loop
     }
+  }
 
-    fn get_next_cmd_id(&self) -> f64 {
-        self.next_cmd_id.fetch_add(1, Ordering::SeqCst) as f64
-    }
+  fn get_next_cmd_id(&self) -> f64 {
+    self.next_cmd_id.fetch_add(1, Ordering::SeqCst) as f64
+  }
 
-    pub fn new_stream(&mut self) -> NetStream {
-        // looks like stream id is created on the server
-        let cmd_id = self.get_next_cmd_id();
-        let to_server_tx = self.to_server_tx.clone();
-        self.runtime.block_on( async move {
-          create_stream(cmd_id, to_server_tx ).await;
-        });
-        NetStream::Command(cmd_id)
-    }
+  pub fn new_stream(&mut self) -> NetStream {
+    // looks like stream id is created on the server
+    let cmd_id = self.get_next_cmd_id();
+    let to_server_tx = self.to_server_tx.clone();
+    let mut runtime = self.runtime_guard.lock().unwrap();
 
-    //     to_server_rx: ownership moves to the spawned thread, its job is to
-    //                  recv messages on this channel and send 'em to the server
-    //  from_server_tx: the thread also listens on the socket, reads messages
-    //                  and sends them on this channel
-    fn spawn_socket_process_loop(
-        &mut self,
-        to_server_rx: mpsc::Receiver<Message>,
-        from_server_tx: mpsc::Sender<Message>,
-    ) {
-        let url = self.url.clone();
-        let _cn_handle = self.runtime.spawn(async move {
-            trace!(target: "rtmp:connect_with_callback", "spawn socket handler");
-            let mut cn = InnerConnection::new(url, to_server_rx).await;
-            cn.connect().await.expect("rtmp connection");
-            cn.process_message_loop(from_server_tx)
-                .await
-                .expect("read until socket closes");
-        });
-    }
+    runtime.block_on(async move {
+      create_stream(cmd_id, to_server_tx).await;
+    });
+    NetStream::Command(cmd_id)
+  }
 
-    pub fn spawn_message_receiver(
-        &mut self,
-        f: impl Fn(Message) -> () + Send + 'static,
-        mut from_server_rx: mpsc::Receiver<Message>,
-    ) {
-        let to_server_tx = self.to_server_tx.clone();
-        let _res_handle = self.runtime.spawn(async move {
-          trace!(target: "rtmp:message_receiver", "spawn recv handler");
-          let mut num:i32 = 1; // just for debugging
-          loop {
-            let msg = from_server_rx.recv().await.expect("recv from server");
-            trace!(target: "rtmp:message_receiver", "#{}) recv from server {:?}", num, msg);
-            if let Some(status) = msg.get_status() {
-              let v: Vec<&str> = status.code.split('.').collect();
-              match v[0] {
-                "NetConnection" => f(msg),
-                _ => warn!(target: "rtmp:message_receiver", "unhandled status {:?}", status),
-              }
-            } else {
+  //     to_server_rx: ownership moves to the spawned thread, its job is to
+  //                  recv messages on this channel and send 'em to the server
+  //  from_server_tx: the thread also listens on the socket, reads messages
+  //                  and sends them on this channel
+  fn spawn_socket_process_loop(
+    &mut self,
+    to_server_rx: mpsc::Receiver<Message>,
+    from_server_tx: mpsc::Sender<Message>,
+  ) {
+    let url = self.url.clone();
+    let mut runtime = self.runtime_guard.lock().unwrap();
+    let _cn_handle = runtime.spawn(async move {
+      trace!(target: "rtmp:connect_with_callback", "spawn socket handler");
+      let mut cn = InnerConnection::new(url, to_server_rx).await;
+      cn.connect().await.expect("rtmp connection");
+      cn.process_message_loop(from_server_tx)
+        .await
+        .expect("read until socket closes");
+    });
+  }
+
+  pub fn spawn_message_receiver(
+    &mut self,
+    f: impl Fn(Message) -> () + Send + 'static,
+    mut from_server_rx: mpsc::Receiver<Message>,
+  ) {
+    let to_server_tx = self.to_server_tx.clone();
+    let mut runtime = self.runtime_guard.lock().unwrap();
+
+    let _res_handle = runtime.spawn(async move {
+      trace!(target: "rtmp:message_receiver", "spawn recv handler");
+      let mut num: i32 = 1; // just for debugging
+      loop {
+        let msg = from_server_rx.recv().await.expect("recv from server");
+        trace!(target: "rtmp:message_receiver", "#{}) recv from server {:?}", num, msg);
+        if let Some(status) = msg.get_status() {
+          let v: Vec<&str> = status.code.split('.').collect();
+          match v[0] {
+            "NetConnection" => f(msg),
+            _ => warn!(target: "rtmp:message_receiver", "unhandled status {:?}", status),
+          }
+        } else {
           match msg {
-            Message::Response { id, data:_, opt } => {
+            Message::Response { id, data: _, opt } => {
               if id == 2.0 {
-                match opt { 
+                match opt {
                   Value::Number(stream_id) => {
                     // create stream
                     trace!(target: "rtmp:message_receiver", "publish");
-                    publish(stream_id as u32,
+                    publish(
+                      stream_id as u32,
                       to_server_tx.clone(),
                       "cameraFeed".to_string(),
                       RecordFlag::Live,
-                    ).await;
-                  },
+                    )
+                    .await;
+                  }
                   _ => {
                     warn!(target: "rtmp:message_receiver", "unexpected opt type {:?}", opt);
-                  } 
+                  }
                 } // match opt
               } // id == 2.0
             }
@@ -123,22 +132,22 @@ impl Connection {
         num += 1;
       }
     });
-    }
+  }
 
-    // std API that returns immediately, then calls callback later
-    pub fn connect_with_callback(
-        &mut self,
-        f: impl Fn(Message) -> () + Send + 'static,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        trace!(target: "rtmp:connect_with_callback", "url: {}", self.url);
-        let (from_server_tx, from_server_rx) = mpsc::channel::<Message>(CHANNEL_SIZE);
-        // ownership will move to thread for processing messages
-        let to_server_rx_option = std::mem::replace(&mut self.to_server_rx, None);
-        let to_server_rx = to_server_rx_option.expect("to_server_rx should be defined");
+  // std API that returns immediately, then calls callback later
+  pub fn connect_with_callback(
+    &mut self,
+    f: impl Fn(Message) -> () + Send + 'static,
+  ) -> Result<(), Box<dyn std::error::Error>> {
+    trace!(target: "rtmp:connect_with_callback", "url: {}", self.url);
+    let (from_server_tx, from_server_rx) = mpsc::channel::<Message>(CHANNEL_SIZE);
+    // ownership will move to thread for processing messages
+    let to_server_rx_option = std::mem::replace(&mut self.to_server_rx, None);
+    let to_server_rx = to_server_rx_option.expect("to_server_rx should be defined");
 
-        self.spawn_socket_process_loop(to_server_rx, from_server_tx);
-        self.spawn_message_receiver(f, from_server_rx);
+    self.spawn_socket_process_loop(to_server_rx, from_server_tx);
+    self.spawn_message_receiver(f, from_server_rx);
 
-        Ok(())
-    }
+    Ok(())
+  }
 }

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -22,75 +22,102 @@ pub mod handshake;
 const CHANNEL_SIZE: usize = 100;
 
 pub struct Connection {
-  url: Url,
-  runtime_guard: Arc<Mutex<Runtime>>,
-  next_cmd_id: AtomicUsize,
-  to_server_tx: mpsc::Sender<Message>, // messages destined for server go here
-  to_server_rx: Option<mpsc::Receiver<Message>>, // process loop grabs them from here
+    url: Url,
+    runtime_guard: Arc<Mutex<Runtime>>,
+    next_cmd_id: AtomicUsize,
+    to_server_tx: mpsc::Sender<Message>, // messages destined for server go here
+    to_server_rx: Option<mpsc::Receiver<Message>>, // process loop grabs them from here
+    stream_callback: fn(Message) -> (),
 }
 
+// how to support closure as well as functions?
+//     stream_callback: dyn Fn(Message) -> (),
+//
+// 35 |     pub fn new(url: Url, stream_callback: dyn Fn(Message) -> ()) -> Self {
+//    |                          ^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+//    |
+//    = help: the trait `std::marker::Sized` is not implemented for `(dyn std::ops::Fn(message::Message) + 'static)`
+//    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
+//    = note: all local variables must have a statically known size
+//    = help: unsized locals are gated as an unstable feature
+
+// error[E0277]: the size for values of type `(dyn std::ops::Fn(message::Message) + 'static)` cannot be known at compilation time
+//   --> src/connection/mod.rs:35:69
+//    |
+// 35 |     pub fn new(url: Url, stream_callback: dyn Fn(Message) -> ()) -> Self {
+//    |                                                                     ^^^^ doesn't have a size known at compile-time
+//    |
+
+fn default_stream_callback(msg: Message) {
+    println!("default stream callback for {:?}", msg);
+}
 impl Connection {
-  // todo: new_with_transport, then new can defer creation of connection
-  pub fn new(url: Url) -> Self {
-    info!(target: "rtmp::Connection", "new");
-    let runtime = tokio::runtime::Runtime::new().expect("new Runtime");
-    let (to_server_tx, to_server_rx) = mpsc::channel::<Message>(CHANNEL_SIZE);
+    // todo: new_with_transport, then new can defer creation of connection
+    pub fn new(url: Url, maybe_stream_callback: Option<fn(Message) -> ()>) -> Self {
+        info!(target: "rtmp::Connection", "new");
+        let stream_callback = match maybe_stream_callback {
+            Some(cb) => cb,
+            None => default_stream_callback,
+        };
+        let runtime = tokio::runtime::Runtime::new().expect("new Runtime");
+        let (to_server_tx, to_server_rx) = mpsc::channel::<Message>(CHANNEL_SIZE);
 
-    Connection {
-      url,
-      runtime_guard: Arc::new(Mutex::new(runtime)),
-      next_cmd_id: AtomicUsize::new(2),
-      to_server_tx,
-      to_server_rx: Some(to_server_rx), // consumed by process_loop
+        Connection {
+            url,
+            runtime_guard: Arc::new(Mutex::new(runtime)),
+            next_cmd_id: AtomicUsize::new(2),
+            to_server_tx,
+            to_server_rx: Some(to_server_rx), // consumed by process_loop
+            stream_callback,
+        }
     }
-  }
 
-  fn get_next_cmd_id(&self) -> f64 {
-    self.next_cmd_id.fetch_add(1, Ordering::SeqCst) as f64
-  }
+    fn get_next_cmd_id(&self) -> f64 {
+        self.next_cmd_id.fetch_add(1, Ordering::SeqCst) as f64
+    }
 
-  pub fn new_stream(&mut self) -> NetStream {
-    // looks like stream id is created on the server
-    let cmd_id = self.get_next_cmd_id();
-    let to_server_tx = self.to_server_tx.clone();
-    let mut runtime = self.runtime_guard.lock().unwrap();
+    pub fn new_stream(&mut self) -> NetStream {
+        // looks like stream id is created on the server
+        let cmd_id = self.get_next_cmd_id();
+        let to_server_tx = self.to_server_tx.clone();
+        let mut runtime = self.runtime_guard.lock().unwrap();
 
-    runtime.block_on(async move {
-      create_stream(cmd_id, to_server_tx).await;
-    });
-    NetStream::Command(cmd_id)
-  }
+        runtime.block_on(async move {
+            create_stream(cmd_id, to_server_tx).await;
+        });
+        NetStream::Command(cmd_id)
+    }
 
-  //     to_server_rx: ownership moves to the spawned thread, its job is to
-  //                  recv messages on this channel and send 'em to the server
-  //  from_server_tx: the thread also listens on the socket, reads messages
-  //                  and sends them on this channel
-  fn spawn_socket_process_loop(
-    &mut self,
-    to_server_rx: mpsc::Receiver<Message>,
-    from_server_tx: mpsc::Sender<Message>,
-  ) {
-    let url = self.url.clone();
-    let mut runtime = self.runtime_guard.lock().unwrap();
-    let _cn_handle = runtime.spawn(async move {
-      trace!(target: "rtmp:connect_with_callback", "spawn socket handler");
-      let mut cn = InnerConnection::new(url, to_server_rx).await;
-      cn.connect().await.expect("rtmp connection");
-      cn.process_message_loop(from_server_tx)
-        .await
-        .expect("read until socket closes");
-    });
-  }
+    //     to_server_rx: ownership moves to the spawned thread, its job is to
+    //                  recv messages on this channel and send 'em to the server
+    //  from_server_tx: the thread also listens on the socket, reads messages
+    //                  and sends them on this channel
+    fn spawn_socket_process_loop(
+        &mut self,
+        to_server_rx: mpsc::Receiver<Message>,
+        from_server_tx: mpsc::Sender<Message>,
+    ) {
+        let url = self.url.clone();
+        let mut runtime = self.runtime_guard.lock().unwrap();
+        let _cn_handle = runtime.spawn(async move {
+            trace!(target: "rtmp:connect_with_callback", "spawn socket handler");
+            let mut cn = InnerConnection::new(url, to_server_rx).await;
+            cn.connect().await.expect("rtmp connection");
+            cn.process_message_loop(from_server_tx)
+                .await
+                .expect("read until socket closes");
+        });
+    }
 
-  pub fn spawn_message_receiver(
-    &mut self,
-    f: impl Fn(Message) -> () + Send + 'static,
-    mut from_server_rx: mpsc::Receiver<Message>,
-  ) {
-    let to_server_tx = self.to_server_tx.clone();
-    let mut runtime = self.runtime_guard.lock().unwrap();
+    pub fn spawn_message_receiver(
+        &mut self,
+        f: impl Fn(Message) -> () + Send + 'static,
+        mut from_server_rx: mpsc::Receiver<Message>,
+    ) {
+        let to_server_tx = self.to_server_tx.clone();
+        let mut runtime = self.runtime_guard.lock().unwrap();
 
-    let _res_handle = runtime.spawn(async move {
+        let _res_handle = runtime.spawn(async move {
       trace!(target: "rtmp:message_receiver", "spawn recv handler");
       let mut num: i32 = 1; // just for debugging
       loop {
@@ -132,22 +159,22 @@ impl Connection {
         num += 1;
       }
     });
-  }
+    }
 
-  // std API that returns immediately, then calls callback later
-  pub fn connect_with_callback(
-    &mut self,
-    f: impl Fn(Message) -> () + Send + 'static,
-  ) -> Result<(), Box<dyn std::error::Error>> {
-    trace!(target: "rtmp:connect_with_callback", "url: {}", self.url);
-    let (from_server_tx, from_server_rx) = mpsc::channel::<Message>(CHANNEL_SIZE);
-    // ownership will move to thread for processing messages
-    let to_server_rx_option = std::mem::replace(&mut self.to_server_rx, None);
-    let to_server_rx = to_server_rx_option.expect("to_server_rx should be defined");
+    // std API that returns immediately, then calls callback later
+    pub fn connect_with_callback(
+        &mut self,
+        f: impl Fn(Message) -> () + Send + 'static,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        trace!(target: "rtmp:connect_with_callback", "url: {}", self.url);
+        let (from_server_tx, from_server_rx) = mpsc::channel::<Message>(CHANNEL_SIZE);
+        // ownership will move to thread for processing messages
+        let to_server_rx_option = std::mem::replace(&mut self.to_server_rx, None);
+        let to_server_rx = to_server_rx_option.expect("to_server_rx should be defined");
 
-    self.spawn_socket_process_loop(to_server_rx, from_server_tx);
-    self.spawn_message_receiver(f, from_server_rx);
+        self.spawn_socket_process_loop(to_server_rx, from_server_tx);
+        self.spawn_message_receiver(f, from_server_rx);
 
-    Ok(())
-  }
+        Ok(())
+    }
 }

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -22,12 +22,11 @@ const CHANNEL_SIZE: usize = 100;
 
 #[derive(Clone)]
 pub struct Connection {
-    url: Url,
-    runtime_guard: Arc<Mutex<Runtime>>,
-    next_cmd_id: Arc<AtomicUsize>,
-    to_server_tx: mpsc::Sender<Message>, // messages destined for server go here
-    to_server_rx: Option<mpsc::Receiver<Message>>, // process loop grabs them from here
-    stream_callback: fn(Message) -> (),
+  url: Url,
+  runtime_guard: Arc<Mutex<Runtime>>,
+  next_cmd_id: Arc<AtomicUsize>,
+  to_server_tx: Option<mpsc::Sender<Message>>, // messages destined server go here
+  stream_callback: fn(Message) -> (),
 }
 
 // how to support closure as well as functions?
@@ -49,76 +48,77 @@ pub struct Connection {
 //    |
 
 fn default_stream_callback(msg: Message) {
-    println!("default stream callback for {:?}", msg);
+  println!("default stream callback for {:?}", msg);
 }
 impl Connection {
-    // todo: new_with_transport, then new can defer creation of connection
-    pub fn new(url: Url, maybe_stream_callback: Option<fn(Message) -> ()>) -> Self {
-        info!(target: "rtmp::Connection", "new");
-        let stream_callback = match maybe_stream_callback {
-            Some(cb) => cb,
-            None => default_stream_callback,
-        };
-        let runtime = tokio::runtime::Runtime::new().expect("new Runtime");
-        let (to_server_tx, to_server_rx) = mpsc::channel::<Message>(CHANNEL_SIZE);
+  // todo: new_with_transport, then new can defer creation of connection
+  pub fn new(url: Url, maybe_stream_callback: Option<fn(Message) -> ()>) -> Self {
+    info!(target: "rtmp::Connection", "new");
+    let stream_callback = match maybe_stream_callback {
+      Some(cb) => cb,
+      None => default_stream_callback,
+    };
+    let runtime = tokio::runtime::Runtime::new().expect("new Runtime");
 
-        Connection {
-            url,
-            runtime_guard: Arc::new(Mutex::new(runtime)),
-            next_cmd_id: Arc::new(AtomicUsize::new(2)),
-            to_server_tx,
-            to_server_rx: Some(to_server_rx), // consumed by process_loop
-            stream_callback,
-        }
+    Connection {
+      url,
+      runtime_guard: Arc::new(Mutex::new(runtime)),
+      next_cmd_id: Arc::new(AtomicUsize::new(2)),
+      to_server_tx: None,
+      stream_callback,
     }
+  }
 
-    fn get_next_cmd_id(&self) -> f64 {
-        self.next_cmd_id.fetch_add(1, Ordering::SeqCst) as f64
-    }
+  fn get_next_cmd_id(&self) -> f64 {
+    self.next_cmd_id.fetch_add(1, Ordering::SeqCst) as f64
+  }
 
-    pub fn new_stream(&mut self) -> NetStream {
-        // looks like stream id is created on the server
-        let cmd_id = self.get_next_cmd_id();
-        let to_server_tx = self.to_server_tx.clone();
-        let mut runtime = self.runtime_guard.lock().unwrap();
+  pub fn new_stream(&mut self) -> NetStream {
+    // looks like stream id is created on the server
+    let cmd_id = self.get_next_cmd_id();
+    let to_server_tx = match &self.to_server_tx {
+      Some(tx) => tx.clone(),
+      None => panic!("need to be connected"),
+    };
+    let mut runtime = self.runtime_guard.lock().unwrap();
 
-        runtime.block_on(async move {
-            create_stream(cmd_id, to_server_tx).await;
-        });
-        NetStream::Command(cmd_id)
-    }
+    runtime.block_on(async move {
+      create_stream(cmd_id, to_server_tx).await;
+    });
+    NetStream::Command(cmd_id)
+  }
 
-    //     to_server_rx: ownership moves to the spawned thread, its job is to
-    //                  recv messages on this channel and send 'em to the server
-    //  from_server_tx: the thread also listens on the socket, reads messages
-    //                  and sends them on this channel
-    fn spawn_socket_process_loop(
-        &mut self,
-        to_server_rx: mpsc::Receiver<Message>,
-        from_server_tx: mpsc::Sender<Message>,
-    ) {
-        let url = self.url.clone();
-        let mut runtime = self.runtime_guard.lock().unwrap();
-        let _cn_handle = runtime.spawn(async move {
-            trace!(target: "rtmp:connect_with_callback", "spawn socket handler");
-            let mut cn = InnerConnection::new(url, to_server_rx).await;
-            cn.connect().await.expect("rtmp connection");
-            cn.process_message_loop(from_server_tx)
-                .await
-                .expect("read until socket closes");
-        });
-    }
+  //     to_server_rx: ownership moves to the spawned thread, its job is to
+  //                  recv messages on this channel and send 'em to the server
+  //  from_server_tx: the thread also listens on the socket, reads messages
+  //                  and sends them on this channel
+  fn spawn_socket_process_loop(
+    &mut self,
+    to_server_rx: mpsc::Receiver<Message>,
+    from_server_tx: mpsc::Sender<Message>,
+  ) {
+    let url = self.url.clone();
+    let mut runtime = self.runtime_guard.lock().unwrap();
+    let _cn_handle = runtime.spawn(async move {
+      trace!(target: "rtmp:connect_with_callback", "spawn socket handler");
+      let mut cn = InnerConnection::new(url, to_server_rx).await;
+      cn.connect().await.expect("rtmp connection");
+      cn.process_message_loop(from_server_tx)
+        .await
+        .expect("read until socket closes");
+    });
+  }
 
-    pub fn spawn_message_receiver(
-        &mut self,
-        f: impl Fn(Message) -> () + Send + 'static,
-        mut from_server_rx: mpsc::Receiver<Message>,
-    ) {
-        let to_server_tx = self.to_server_tx.clone();
-        let mut runtime = self.runtime_guard.lock().unwrap();
+  pub fn spawn_message_receiver(
+    &mut self,
+    f: impl Fn(Message) -> () + Send + 'static,
+    mut from_server_rx: mpsc::Receiver<Message>,
+  ) {
+    let to_server_tx = Some(self.to_server_tx.as_ref()).unwrap().clone();
+    let mut runtime = self.runtime_guard.lock().unwrap();
 
-        let stream_callback = self.stream_callback;
-        let _res_handle = runtime.spawn(async move {
+    let stream_callback = self.stream_callback;
+    let _res_handle = runtime.spawn(async move {
       trace!(target: "rtmp:message_receiver", "spawn recv handler");
       let mut num: i32 = 1; // just for debugging
       loop {
@@ -132,8 +132,7 @@ impl Connection {
           }
         } else {
           match msg {
-            Message::Response {id, .. } => {
-
+            Message::Response { id, .. } => {
               if id == 2.0 {
                 trace!(target: "rtmp:message_receiver", "about to call stream_callback");
                 stream_callback(msg);
@@ -163,22 +162,23 @@ impl Connection {
         num += 1;
       }
     });
-    }
+  }
 
-    // std API that returns immediately, then calls callback later
-    pub fn connect_with_callback(
-        &mut self,
-        f: impl Fn(Message) -> () + Send + 'static,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        trace!(target: "rtmp:connect_with_callback", "url: {}", self.url);
-        let (from_server_tx, from_server_rx) = mpsc::channel::<Message>(CHANNEL_SIZE);
-        // ownership will move to thread for processing messages
-        let to_server_rx_option = std::mem::replace(&mut self.to_server_rx, None);
-        let to_server_rx = to_server_rx_option.expect("to_server_rx should be defined");
+  // std API that returns immediately, then calls callback later
+  pub fn connect_with_callback(
+    &mut self,
+    f: impl Fn(Message) -> () + Send + 'static,
+  ) -> Result<(), Box<dyn std::error::Error>> {
+    trace!(target: "rtmp:connect_with_callback", "url: {}", self.url);
+    let (from_server_tx, from_server_rx) = mpsc::channel::<Message>(CHANNEL_SIZE);
 
-        self.spawn_socket_process_loop(to_server_rx, from_server_tx);
-        self.spawn_message_receiver(f, from_server_rx);
+    let (to_server_tx, to_server_rx) = mpsc::channel::<Message>(CHANNEL_SIZE);
 
-        Ok(())
-    }
+    self.to_server_tx = Some(to_server_tx); // Connection methods use this to send messages to server
+
+    self.spawn_socket_process_loop(to_server_rx, from_server_tx);
+    self.spawn_message_receiver(f, from_server_rx);
+
+    Ok(())
+  }
 }

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -114,9 +114,8 @@ impl Connection {
     f: impl Fn(Message) -> () + Send + 'static,
     mut from_server_rx: mpsc::Receiver<Message>,
   ) {
-    let to_server_tx = Some(self.to_server_tx.as_ref()).unwrap().clone();
     let mut runtime = self.runtime_guard.lock().unwrap();
-
+    let connection = self.clone();
     let stream_callback = self.stream_callback;
     let _res_handle = runtime.spawn(async move {
       trace!(target: "rtmp:message_receiver", "spawn recv handler");
@@ -135,6 +134,8 @@ impl Connection {
             Message::Response { id, .. } => {
               if id == 2.0 {
                 trace!(target: "rtmp:message_receiver", "about to call stream_callback");
+                let to_server_tx = Some(connection.to_server_tx.as_ref()).unwrap().clone();
+
                 stream_callback(msg);
                 // match opt {
                 //   Value::Number(stream_id) => {

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -1,7 +1,6 @@
 use log::{info, trace, warn};
-use std::sync::{Arc, Mutex};
-
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
 use tokio::runtime::Runtime;
 use tokio::sync::mpsc;
 use url::Url;
@@ -21,10 +20,11 @@ pub mod handshake;
 // TODO: maybe this should be configurable?
 const CHANNEL_SIZE: usize = 100;
 
+#[derive(Clone)]
 pub struct Connection {
     url: Url,
     runtime_guard: Arc<Mutex<Runtime>>,
-    next_cmd_id: AtomicUsize,
+    next_cmd_id: Arc<AtomicUsize>,
     to_server_tx: mpsc::Sender<Message>, // messages destined for server go here
     to_server_rx: Option<mpsc::Receiver<Message>>, // process loop grabs them from here
     stream_callback: fn(Message) -> (),
@@ -65,7 +65,7 @@ impl Connection {
         Connection {
             url,
             runtime_guard: Arc::new(Mutex::new(runtime)),
-            next_cmd_id: AtomicUsize::new(2),
+            next_cmd_id: Arc::new(AtomicUsize::new(2)),
             to_server_tx,
             to_server_rx: Some(to_server_rx), // consumed by process_loop
             stream_callback,


### PR DESCRIPTION
In master, publishing a stream is hard-coded, publish is called automatically on successful create (actually successful response to transaction #2)

I think it might be good to have an API like this:
```
  cn.connect_with_callback(|cn, response| {
      cn.new_stream(|cn, stream| {
        stream.publish("mystream".to_string(), rtmp::RecordFlag::Live);
        println!("===> published: {}", stream);
      };
    })
    .expect("rtmp connect");
```

This PR starts that refactor.  